### PR TITLE
Groovy Template QoL Changes

### DIFF
--- a/src/main/java/net/tcgone/carddb/tools/CoreCollection.java
+++ b/src/main/java/net/tcgone/carddb/tools/CoreCollection.java
@@ -155,6 +155,10 @@ public enum CoreCollection {
 	SHINY_VAULT(426, "SMA", "sma"),
 	COSMIC_ECLIPSE(427, "CEC", "sm12"),
 
+	// Sword & Shield
+	SWORD_SHIELD(430, "SSH", "swsh1"),
+	REBEL_CLASH(431, "RCL", "swsh2"),
+
 	//POKEMOD
 	POKEMOD_BASE_SET(911, "PMDBS", null),
 	POKEMOD_JUNGLE(912, "PMDJU", null),

--- a/src/main/java/net/tcgone/carddb/tools/ImplTmplGenerator.java
+++ b/src/main/java/net/tcgone/carddb/tools/ImplTmplGenerator.java
@@ -156,6 +156,11 @@ public class ImplTmplGenerator {
 						}
 						if(m.text!=null)
 							movedesc+=m.text;
+
+						String trailingString = "\n\t\t\t\t";
+						if (card.moves.indexOf(m) == (card.moves.size() -1)) {
+							trailingString = "";
+						}  	
 						moves.append(String.format("move \"%s\", {\n" +
 								"\t\t\t\t\ttext \"%s\"\n" +
 								"\t\t\t\t\tenergyCost %s\n" +
@@ -163,8 +168,8 @@ public class ImplTmplGenerator {
 								"\t\t\t\t\tonAttack {\n" +
 								"\t\t\t\t\t\t%s\n" +
 								"\t\t\t\t\t}\n" +
-								"\t\t\t\t}\n\t\t\t\t", m.name, movedesc, StringUtils.join(m.cost,", "),movedamg!=null?"damage "+movedamg:""));
-
+								"\t\t\t\t}%s", m.name, movedesc, StringUtils.join(m.cost,", "),movedamg!=null?"damage "+movedamg:"", trailingString));
+						
 					}
 				}
 			}
@@ -182,7 +187,7 @@ public class ImplTmplGenerator {
 						"\t\t\t}", 
 						hp, typesCombined, rc, weakness.toString(), resistance.toString(), abilities.toString(), moves.toString());
 			}
-			else if (cardTypeSet.contains("EVOLUTION")) {
+			else if (cardTypeSet.contains("EVOLUTION") || cardTypeSet.contains("VMAX")) {
 				impl =  String.format("evolution (this, from:\"%s\", hp:%s, type:%s, retreatCost:%s) {\n" +
 						"\t\t\t\t%s%s%s%s\n" +
 						"\t\t\t}", 

--- a/src/main/java/net/tcgone/carddb/tools/PioReader.java
+++ b/src/main/java/net/tcgone/carddb/tools/PioReader.java
@@ -68,7 +68,10 @@ public class PioReader {
 					.replace("rare holo ex","Ultra Rare")
 					.replace("rare holo gx","Ultra Rare")
 					.replace("rare promo","Promo")
-					.replace("legend","Ultra Rare");
+					.replace("legend","Ultra Rare")
+					.replace("rareholovmax", "Rare Holo")
+					.replace("rareholov","Rare Holo");
+
 			pc.rarity= WordUtils.capitalizeFully(pc.rarity);
 			if(!allowedRarities.contains(pc.rarity)){
 				throw new IllegalStateException(pc.rarity+" cannot be accepted as rarity, please fix.");
@@ -103,7 +106,7 @@ public class PioReader {
 	}
 
 	private Set<String> stage1Db = new HashSet<>();
-	private Set<String> modernSeries = ImmutableSet.of("Black & White", "XY", "Sun & Moon");
+	private Set<String> modernSeries = ImmutableSet.of("Black & White", "XY", "Sun & Moon", "Sword & Shield");
 	private Set<String> allowedRarities = ImmutableSet.of("Common","Uncommon","Rare","Ultra Rare","Rare Holo","Secret","Promo");
 	private Map<String,String> typesMap = ImmutableMap.<String,String>builder().put("Fire","R").put("Grass","G").put("Water","W").put("Fighting","F").put("Colorless","C").put("Lightning","L").put("Psychic","P").put("Darkness","D").put("Metal","M").put("Dragon","N").put("Fairy","Y").build();
 	private Map<String, net.tcgone.carddb.model.Set> setMap = new HashMap<>();
@@ -201,6 +204,9 @@ public class PioReader {
 				if(pc.name.contains("-EX")){
 					c.subTypes.add("POKEMON_EX");
 				}
+				if (pc.name.endsWith("V")) {
+					c.subTypes.add("POKEMON_V");
+				}
 				break;
 			case "Stage 1":
 				c.subTypes.add("EVOLUTION");
@@ -245,6 +251,10 @@ public class PioReader {
 				} else {
 					c.subTypes.add("BASIC");
 				}
+				break;
+			case "VMAX":
+				c.subTypes.add("VMAX");
+				c.subTypes.add("EVOLUTION");
 				break;
 			case "MEGA":
 				c.subTypes.add("EVOLUTION");

--- a/src/main/resources/set2.vm
+++ b/src/main/resources/set2.vm
@@ -34,71 +34,70 @@ import tcgwars.logic.util.*;
 /**
  * @author axpendix@hotmail.com
  */
-public enum ${classname} implements CardInfo {
-	
+public enum ${classname} implements LogicCardInfo {
+    
 #foreach( $obj1 in $list1 )
-	${obj1.name} ("${obj1.fullname}", ${obj1.cln}, Rarity.${obj1.rarity}, ${obj1.cardtype}),
+  ${obj1.name} ("${obj1.fullname}", ${obj1.cln}, Rarity.${obj1.rarity}, ${obj1.cardtype}),
 #end;
-	
-	static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
-	
-	protected CardTypeSet cardTypes;
-	protected String name;
-	protected Rarity rarity;
-	protected int collectionLineNo;
+    
+  static Type C = COLORLESS, R = FIRE, F = FIGHTING, G = GRASS, W = WATER, P = PSYCHIC, L = LIGHTNING, M = METAL, D = DARKNESS, Y = FAIRY, N = DRAGON;
+  
+  protected CardTypeSet cardTypes;
+  protected String name;
+  protected Rarity rarity;
+  protected int collectionLineNo;
 
-	${classname}(String name, int collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
-		this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
-		this.name = name;
-		this.rarity = rarity;
-		this.collectionLineNo = collectionLineNo;
-	}
+  ${classname}(String name, int collectionLineNo, Rarity rarity, List<CardType> cardTypes) {
+    this.cardTypes = new CardTypeSet(cardTypes as CardType[]);
+    this.name = name;
+    this.rarity = rarity;
+    this.collectionLineNo = collectionLineNo;
+  }
 
-	@Override
-	public CardTypeSet getCardTypes() {
-		return cardTypes;
-	}
+  @Override
+  public CardTypeSet getCardTypes() {
+    return cardTypes;
+  }
 
-	@Override
-	public String getName() {
-		return name;
-	}
+  @Override
+  public String getName() {
+    return name;
+  }
 
-	@Override
-	public Rarity getRarity() {
-		return rarity;
-	}
+  @Override
+  public Rarity getRarity() {
+    return rarity;
+  }
 
-	@Override
-	public int getCollectionLineNo() {
-		return collectionLineNo;
-	}
+  @Override
+  public int getCollectionLineNo() {
+    return collectionLineNo;
+  }
 
-	@Override
-	public tcgwars.logic.card.Collection getCollection() {
-		return tcgwars.logic.card.Collection.${collection};
-	}
+  @Override
+  public tcgwars.logic.card.Collection getCollection() {
+    return tcgwars.logic.card.Collection.${collection};
+  }
 
-	@Override
-	public String toString() {
-		return String.format("%s:%s", this.name(), this.getCollection().name());
-	}
+  @Override
+  public String toString() {
+    return String.format("%s:%s", this.name(), this.getCollection().name());
+  }
 
-	@Override
-	public String getEnumName() {
-		return name();
-	}
+  @Override
+  public String getEnumName() {
+    return name();
+  }
 
-	@Override
-	public Card getImplementation() {
-		switch (this) {
-		#foreach( $obj2 in $list2 )
-	case ${obj2.name}:
-			return ${obj2.impl};
-		#end
-		default:
-			return null;
-		}
-	}
-	
+  @Override
+  public Card getImplementation() {
+    switch (this) {
+    #foreach( $obj2 in $list2 )
+  case ${obj2.name}:
+      return ${obj2.impl};
+    #end
+    default:
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
This PR includes Quality of Life changes to the template and also adds the latest sets to the Collection file.

The template will now use `LogicCardInfo` instead of `CardInfo` which caused errors when using the groovy template.  The template also has the spacing changed to 2 spaces to match what is currently used in production and `.editorconfig`.

The sets being added are: Sword and Shield and Rebel Clash.  The set introduces two new types, `POKEMON_V` and `VMAX` as well as two new rarities `rareholovmax` and `rareholov`.

I've also gone ahead and removed the empty line that is typically found after the last move in a Pokemon within the groovy template.  The change is in the `ImplTmplGenerator.java` file.

